### PR TITLE
Add /help command test and handler

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -12,12 +12,18 @@ async def start_handler(msg: types.Message):
         parse_mode=ParseMode.HTML,
     )
 
+async def help_handler(msg: types.Message):
+    await msg.answer(
+        "Доступные команды:\n/start — запуск бота\n/help — это сообщение помощи"
+    )
+
 def create_bot_and_dispatcher():          # удобно реиспользовать в тестах
     #bot = Bot(token=BOT_TOKEN)
     token = os.getenv("BOT_TOKEN")
     bot = Bot(token=token)
     dp = Dispatcher()
     dp.message(Command("start"))(start_handler)
+    dp.message(Command("help"))(help_handler)
     return bot, dp
 
 async def main():

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,4 @@
+1. Add help_handler in bot/main.py to handle /help command.
+2. Register /help command in dispatcher inside create_bot_and_dispatcher.
+3. Create tests/test_help.py replicating test_start structure but for /help command, verifying message text includes help info.
+4. Run pytest to ensure all tests pass.

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,58 @@
+# tests/test_help.py
+
+import asyncio
+import pytest
+from datetime import datetime
+from aiogram import types
+from aiogram.types import Update
+from bot.main import create_bot_and_dispatcher
+
+@pytest.fixture(autouse=True)
+def fake_token_env(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123456:FAKE_TOKEN")
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+@pytest.fixture()
+def bot_and_dp(monkeypatch):
+    bot, dp = create_bot_and_dispatcher()
+
+    send_calls = []
+    async def fake_answer(self, text, **kwargs):
+        send_calls.append((self.chat.id, text))
+        return types.Message(
+            message_id=0,
+            date=datetime.now(),
+            chat=self.chat,
+            from_user=self.from_user,
+            text=text,
+        )
+
+    monkeypatch.setattr(types.Message, "answer", fake_answer)
+
+    return bot, dp, send_calls
+
+@pytest.mark.asyncio
+async def test_help_command(bot_and_dp):
+    bot, dp, send_calls = bot_and_dp
+
+    msg = types.Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=types.Chat(id=12345, type="private"),
+        from_user=types.User(id=12345, is_bot=False, first_name="Tester"),
+        text="/help",
+    )
+
+    update = Update(update_id=1, message=msg)
+
+    await dp.feed_update(bot, update)
+
+    assert len(send_calls) == 1
+    chat_id, text = send_calls[0]
+    assert chat_id == 12345
+    assert "доступные команды" in text.lower()


### PR DESCRIPTION
## Summary
- implement `/help` command handler with text listing commands
- register `/help` in dispatcher
- add unit test verifying `/help` response
- document steps in `docs/IMPLEMENTATION_PLAN.md`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853dd9491e8832a9892746beb18d81c