### PR TITLE
Implement ping command and CI tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your Telegram bot token
+BOT_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,29 @@
 name: CI
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
-
     steps:
-      # 1. Клонируем репозиторий
       - uses: actions/checkout@v4
 
-      # 2. Устанавливаем Python 3.11
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
-      # 3. Устанавливаем зависимости
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 
-      # 4. Прогоняем тесты
+      - name: Run lint
+        run: pre-commit run --all-files
+
       - name: Run tests
         env:
           BOT_TOKEN: 123456:FAKE-TOKEN-FOR-CI
         run: python -m pytest -q
+
+      - name: Docker build
+        run: docker build -t bot:test .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-m", "bot.main", "--ping"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Telegram Bot
+
+Simple async bot using aiogram.
+
+## Development
+
+Install dependencies and set up pre-commit:
+
+```bash
+pip install -r requirements.txt
+pre-commit install
+```
+
+Run tests:
+
+```bash
+pytest -q
+```

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,10 +1,13 @@
 # bot/main.py
-import asyncio, os
+import argparse
+import asyncio
+import os
+
 from aiogram import Bot, Dispatcher, types
 from aiogram.enums import ParseMode
 from aiogram.filters import Command
+from dotenv import load_dotenv
 
-BOT_TOKEN = os.getenv("BOT_TOKEN")
 
 async def start_handler(msg: types.Message):
     await msg.answer(
@@ -12,23 +15,45 @@ async def start_handler(msg: types.Message):
         parse_mode=ParseMode.HTML,
     )
 
+
 async def help_handler(msg: types.Message):
     await msg.answer(
-        "Доступные команды:\n/start — запуск бота\n/help — это сообщение помощи"
+        """Доступные команды:
+/start — запуск бота
+/help — это сообщение помощи"""
     )
 
-def create_bot_and_dispatcher():          # удобно реиспользовать в тестах
-    #bot = Bot(token=BOT_TOKEN)
+
+async def ping_handler(msg: types.Message):
+    await msg.answer("Bot ready")
+
+
+def create_bot_and_dispatcher():  # удобно реиспользовать в тестах
     token = os.getenv("BOT_TOKEN")
     bot = Bot(token=token)
     dp = Dispatcher()
     dp.message(Command("start"))(start_handler)
     dp.message(Command("help"))(help_handler)
+    dp.message(Command("ping"))(ping_handler)
     return bot, dp
+
 
 async def main():
     bot, dp = create_bot_and_dispatcher()
     await dp.start_polling(bot)
 
-if __name__ == "__main__":
+
+def cli(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ping", action="store_true")
+    args = parser.parse_args(argv)
+    load_dotenv()
+    if args.ping:
+        print("pong")
+        return 0
     asyncio.run(main())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli())

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -19,17 +19,20 @@
 
 | Модуль       | Описание                        | Файлы и папки                                                    |
 | ------------ | ------------------------------- | ---------------------------------------------------------------- |
-| **bot-core** | Логика Telegram-бота            | `main.py` (`start_handler`, `create_bot_and_dispatcher`, `main`) |
+| **bot-core** | Логика Telegram-бота            | `main.py` (`start_handler`, `help_handler`, `ping_handler`, `create_bot_and_dispatcher`, `main`, `cli`) |
 | **database** | Инициализация и миграции БД     | `database.py` (`init_db`, `CREATE_USERS`)                        |
-| **tests**    | Юнит- и E2E-тесты               | `tests/conftest.py`, `tests/test_start.py`                       |
-| **config**   | Конфигурация окружения          | `.env` (переменная `BOT_TOKEN`)                                  |
-| **CI/CD**    | Настройка сборки и тестирования | `.github/workflows/ci.yml`                                       |
+| **tests**    | Юнит- и E2E-тесты               | `tests/conftest.py`, `tests/test_start.py`, `tests/test_help.py`, `tests/test_smoke.py`                       |
+| **config**   | Конфигурация окружения          | `.env`, `.env.example` (переменная `BOT_TOKEN`)                                  |
+| **CI/CD**    | Настройка сборки и тестирования | `.github/workflows/ci.yml`, `.pre-commit-config.yaml`, `Dockerfile`                                       |
 | **deps**     | Зависимости проекта             | `requirements.txt`                                               |
+| **docs**     | Описание разработки             | `README.md`                                            |
 
 ## 3. Навигация для агентов
 
 * **Изменить логику команд бота:** см. `main.py`, функции `start_handler` и регистрация команд в `create_bot_and_dispatcher()`.
 * **Добавить новые поля в User:** редактируйте `CREATE TABLE users` в `database.py` и обновляйте `init_db()`.
+* **CLI-проверка:** `python -m bot.main --ping` выводит "pong".
+* **Запуск lint:** `pre-commit run --all-files`.
 * **Тесты на новые функции бота:** добавляйте файлы в папку `tests/`, используйте `pytest` и мок `BOT_TOKEN` через `conftest.py`.
 * **CI-пайплайн:** для проверки lint, тестов и автодеплоя смотрите `.github/workflows/ci.yml`.
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,62 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+from aiogram import types
+from aiogram.types import Update
+
+from bot.main import create_bot_and_dispatcher
+
+
+@pytest.fixture(autouse=True)
+def fake_token_env(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123456:FAKE_TOKEN")
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture()
+def bot_and_dp(monkeypatch):
+    bot, dp = create_bot_and_dispatcher()
+
+    send_calls = []
+
+    async def fake_answer(self, text, **kwargs):
+        send_calls.append((self.chat.id, text))
+        return types.Message(
+            message_id=0,
+            date=datetime.now(),
+            chat=self.chat,
+            from_user=self.from_user,
+            text=text,
+        )
+
+    monkeypatch.setattr(types.Message, "answer", fake_answer)
+    return bot, dp, send_calls
+
+
+@pytest.mark.asyncio
+async def test_ping_command(bot_and_dp):
+    bot, dp, send_calls = bot_and_dp
+
+    msg = types.Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=types.Chat(id=12345, type="private"),
+        from_user=types.User(id=12345, is_bot=False, first_name="Tester"),
+        text="/ping",
+    )
+
+    update = Update(update_id=1, message=msg)
+
+    await dp.feed_update(bot, update)
+
+    assert len(send_calls) == 1
+    chat_id, text = send_calls[0]
+    assert chat_id == 12345
+    assert text == "Bot ready"


### PR DESCRIPTION
## Summary
- add `/ping` command with CLI entry
- configure pre-commit and lint in CI
- create Dockerfile and environment example
- document development workflow
- update context documentation
- revert requirements to previous state

## Testing
- `pre-commit run --files requirements.txt`
- `pytest -q`
- `python -m bot.main --ping`


------
https://chatgpt.com/codex/tasks/task_e_68551b6cf470832a96bf001936e590d5