### PR TITLE
Implement DB schema and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
           python-version: '3.12'
       - name: Install deps
         run: pip install -r requirements.txt pre-commit
+      - name: DB tests
+        run: pytest -q tests/db
       - name: Lint
         run: pre-commit run --all-files
       - name: Test

--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ Run tests:
 ```bash
 pytest -q
 ```
+
+## Database
+
+The bot uses a SQLite file `bot.db`. It is created by calling `init_db()` from
+`bot/database.py`. Foreign key support is enabled via
+`PRAGMA foreign_keys=ON` during initialization.

--- a/bot/database.py
+++ b/bot/database.py
@@ -1,4 +1,16 @@
+"""Database schema
+=================
+
+```
+users(id PK, tg_id UNIQUE, name)
+requests(id PK, user_id FK users.id, prompt, model, created_at)
+responses(id PK, request_id FK requests.id, content, created_at)
+models(id PK, provider, name, updated_at)
+```
+"""
+
 import pathlib
+from contextlib import asynccontextmanager
 
 import aiosqlite
 
@@ -12,8 +24,69 @@ CREATE TABLE IF NOT EXISTS users(
 );
 """
 
+CREATE_REQUESTS = """
+CREATE TABLE IF NOT EXISTS requests(
+    id         INTEGER PRIMARY KEY,
+    user_id    INTEGER REFERENCES users(id),
+    prompt     TEXT,
+    model      TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+CREATE_RESPONSES = """
+CREATE TABLE IF NOT EXISTS responses(
+    id         INTEGER PRIMARY KEY,
+    request_id INTEGER REFERENCES requests(id),
+    content    TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+CREATE_MODELS = """
+CREATE TABLE IF NOT EXISTS models(
+    id         INTEGER PRIMARY KEY,
+    provider   TEXT,
+    name       TEXT,
+    updated_at TIMESTAMP
+);
+"""
+
 
 async def init_db():
     async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("PRAGMA foreign_keys=ON")
         await db.execute(CREATE_USERS)
+        await db.execute(CREATE_REQUESTS)
+        await db.execute(CREATE_RESPONSES)
+        await db.execute(CREATE_MODELS)
+        await db.commit()
+
+
+@asynccontextmanager
+async def get_db():
+    db = await aiosqlite.connect(DB_PATH)
+    await db.execute("PRAGMA foreign_keys=ON")
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+async def log_request(user_id: int, prompt: str, model: str) -> int:
+    async with get_db() as db:
+        cur = await db.execute(
+            "INSERT INTO requests(user_id, prompt, model) VALUES(?, ?, ?)",
+            (user_id, prompt, model),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def log_response(request_id: int, content: str) -> None:
+    async with get_db() as db:
+        await db.execute(
+            "INSERT INTO responses(request_id, content) VALUES(?, ?)",
+            (request_id, content),
+        )
         await db.commit()

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -13,14 +13,40 @@
   * `name: TEXT` — имя или никнейм пользователя
 * Хранится в таблице `users` (создаётся в `database.py`).
 
-> Пока единственная модель данных: добавляйте новые поля к User через миграции в `database.py`.
+### Request
+
+* Поля:
+  * `id: INTEGER PRIMARY KEY`
+  * `user_id: INTEGER` — FK на `users.id`
+  * `prompt: TEXT` — текст запроса
+  * `model: TEXT` — название модели
+  * `created_at: TIMESTAMP DEFAULT CURRENT_TIMESTAMP`
+* Таблица `requests`.
+
+### Response
+
+* Поля:
+  * `id: INTEGER PRIMARY KEY`
+  * `request_id: INTEGER` — FK на `requests.id`
+  * `content: TEXT`
+  * `created_at: TIMESTAMP DEFAULT CURRENT_TIMESTAMP`
+* Таблица `responses`.
+
+### Model
+
+* Поля:
+  * `id: INTEGER PRIMARY KEY`
+  * `provider: TEXT`
+  * `name: TEXT`
+  * `updated_at: TIMESTAMP`
+* Таблица `models`.
 
 ## 2. Структура модулей
 
 | Модуль       | Описание                        | Файлы и папки                                                    |
 | ------------ | ------------------------------- | ---------------------------------------------------------------- |
 | **bot-core** | Логика Telegram-бота            | `main.py` (`start_handler`, `help_handler`, `ping_handler`, `create_bot_and_dispatcher`, `main`) |
-| **database** | Инициализация и миграции БД     | `database.py` (`init_db`, `CREATE_USERS`)                        |
+| **database** | Инициализация и миграции БД     | `database.py` (`init_db`, `get_db`, `log_request`, `log_response`, `CREATE_USERS`, `CREATE_REQUESTS`, `CREATE_RESPONSES`, `CREATE_MODELS`) |
 | **tests**    | Юнит- и E2E-тесты               | `tests/conftest.py`, `tests/test_start.py`, `tests/test_help.py`, `tests/test_smoke.py`                       |
 | **config**   | Конфигурация окружения          | `.env` (переменная `BOT_TOKEN`), `.env.example`                                  |
 | **CI/CD**    | Настройка сборки и тестирования | `.github/workflows/ci.yml`                                       |

--- a/tests/db/test_schema.py
+++ b/tests/db/test_schema.py
@@ -1,0 +1,73 @@
+import asyncio
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from bot import database
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest_asyncio.fixture()
+async def temp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+    await database.init_db()
+    return db_path
+
+
+@pytest.mark.asyncio
+async def test_schema_tables(temp_db):
+    async with aiosqlite.connect(temp_db) as db:
+        await db.execute("PRAGMA foreign_keys=ON")
+        query = "SELECT name FROM sqlite_master WHERE type='table';"
+        cur = await db.execute(query)
+        names = {row[0] for row in await cur.fetchall()}
+        assert {"users", "requests", "responses", "models"} <= names
+
+        cur = await db.execute("PRAGMA table_info(requests);")
+        cols = {row[1] for row in await cur.fetchall()}
+        assert {"user_id", "prompt", "model"} <= cols
+
+        cur = await db.execute("PRAGMA foreign_key_list(responses);")
+        fk = await cur.fetchall()
+        assert any(row[2] == "requests" for row in fk)
+
+
+@pytest.mark.asyncio
+async def test_foreign_key_constraints(temp_db):
+    async with aiosqlite.connect(temp_db) as db:
+        await db.execute("PRAGMA foreign_keys=ON")
+        # insert user
+        user_cur = await db.execute(
+            "INSERT INTO users(tg_id, name) VALUES(?, ?)",
+            (1, "user"),
+        )
+        user_id = user_cur.lastrowid
+        # insert request
+        req_cur = await db.execute(
+            "INSERT INTO requests(user_id, prompt, model) VALUES(?, ?, ?)",
+            (user_id, "hi", "model"),
+        )
+        req_id = req_cur.lastrowid
+        await db.commit()
+
+        # valid response
+        await db.execute(
+            "INSERT INTO responses(request_id, content) VALUES(?, ?)",
+            (req_id, "ok"),
+        )
+        await db.commit()
+
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO responses(request_id, content) VALUES(?, ?)",
+                (req_id + 1, "bad"),
+            )
+            await db.commit()


### PR DESCRIPTION
## Summary
- expand sqlite schema and add helper methods
- document schema and update README
- add database tests and CI step

## Testing
- `pre-commit run --files bot/database.py tests/db/test_schema.py README.md docs/CONTEXT.md .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566b4ded28832a8b3e5464699b8eda