### PR TITLE
Implement authorization middleware with admin approval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Copy this file to .env and set your Telegram bot token
 BOT_TOKEN=
+ADMIN_CHAT_ID=0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,6 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
+      - id: mypy
+        name: mypy services
+        files: ^services/

--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ pytest -q
 The bot uses a SQLite file `bot.db`. It is created by calling `init_db()` from
 `bot/database.py`. Foreign key support is enabled via
 `PRAGMA foreign_keys=ON` during initialization.
+
+## Authorization
+
+When a new user sends `/start`, the bot records the request and notifies the chat defined in `ADMIN_CHAT_ID`. Until the admin approves the user, any commands besides `/start` are ignored.

--- a/bot/admin.py
+++ b/bot/admin.py
@@ -1,0 +1,39 @@
+from aiogram import Router, types
+from aiogram.filters import Command
+
+from services import user_service
+
+
+def get_admin_router(admin_chat_id: int) -> Router:
+    router = Router()
+
+    async def approve_cmd(msg: types.Message):
+        parts = msg.text.split()
+        if len(parts) == 3 and parts[1] == "approve":
+            tg_id = int(parts[2])
+            await user_service.set_active(tg_id, True)
+            await msg.answer("Пользователь активирован")
+            await msg.bot.send_message(tg_id, "Доступ открыт")
+
+    async def pending_cmd(msg: types.Message):
+        pending = await user_service.pending_users()
+        lines = [f"{u['tg_id']} — {u['name']}" for u in pending]
+        text = "\n".join(lines) or "Нет заявок"
+        await msg.answer(text)
+
+    router.message.filter(lambda m: m.chat.id == admin_chat_id)
+    router.message(Command("admin"))(approve_cmd)
+    router.message(Command("admin"))(pending_cmd)
+
+    async def approve_callback(cb: types.CallbackQuery):
+        data = cb.data
+        if data and data.startswith("approve:"):
+            tg_id = int(data.split(":", 1)[1])
+            await user_service.set_active(tg_id, True)
+            await cb.message.answer("Пользователь активирован")
+            await cb.bot.send_message(tg_id, "Доступ открыт")
+            await cb.answer()
+
+    router.callback_query(approve_callback)
+
+    return router

--- a/bot/database.py
+++ b/bot/database.py
@@ -2,7 +2,7 @@
 =================
 
 ```
-users(id PK, tg_id UNIQUE, name)
+users(id PK, tg_id UNIQUE, name, is_active, requested_at)
 requests(id PK, user_id FK users.id, prompt, model, created_at)
 responses(id PK, request_id FK requests.id, content, created_at)
 models(id PK, provider, name, updated_at)
@@ -20,7 +20,9 @@ CREATE_USERS = """
 CREATE TABLE IF NOT EXISTS users(
     id     INTEGER PRIMARY KEY,
     tg_id  INTEGER UNIQUE,
-    name   TEXT
+    name   TEXT,
+    is_active INTEGER NOT NULL DEFAULT 0,
+    requested_at TIMESTAMP
 );
 """
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -8,6 +8,9 @@ from aiogram.enums import ParseMode
 from aiogram.filters import Command
 from dotenv import load_dotenv
 
+from bot.admin import get_admin_router
+from bot.middleware import AuthMiddleware
+
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 
 
@@ -34,10 +37,12 @@ async def ping_handler(msg: types.Message):
 
 
 def create_bot_and_dispatcher():  # удобно реиспользовать в тестах
-    # bot = Bot(token=BOT_TOKEN)
     token = os.getenv("BOT_TOKEN")
+    admin_id = int(os.getenv("ADMIN_CHAT_ID", "0"))
     bot = Bot(token=token)
     dp = Dispatcher()
+    dp.message.middleware(AuthMiddleware(admin_id))
+    dp.include_router(get_admin_router(admin_id))
     dp.message(Command("start"))(start_handler)
     dp.message(Command("help"))(help_handler)
     dp.message(Command("ping"))(ping_handler)

--- a/bot/middleware.py
+++ b/bot/middleware.py
@@ -1,0 +1,41 @@
+from aiogram import BaseMiddleware, Bot, types
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from services import user_service
+
+
+class AuthMiddleware(BaseMiddleware):
+    def __init__(self, admin_chat_id: int) -> None:
+        super().__init__()
+        self.admin_chat_id = admin_chat_id
+
+    async def __call__(self, handler, event: types.TelegramObject, data):
+        if isinstance(event, types.Message):
+            tg_id = event.from_user.id
+            name = event.from_user.full_name
+            user = await user_service.get_or_create_user(tg_id, name)
+
+            if tg_id == self.admin_chat_id:
+                return await handler(event, data)
+
+            if self.admin_chat_id == 0:
+                if not user["is_active"]:
+                    await user_service.set_active(tg_id, True)
+                return await handler(event, data)
+
+            if not user["is_active"]:
+                if event.text and event.text.startswith("/start"):
+                    await event.answer("Ваша заявка отправлена администратору")
+                    button = InlineKeyboardButton(
+                        text="✅ Одобрить",
+                        callback_data=f"approve:{tg_id}",
+                    )
+                    markup = InlineKeyboardMarkup(inline_keyboard=[[button]])
+                    bot: Bot = data["bot"]
+                    await bot.send_message(
+                        self.admin_chat_id,
+                        f"Новая заявка от {name} ({tg_id})",
+                        reply_markup=markup,
+                    )
+                return  # block further handling until approved
+        return await handler(event, data)

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -11,6 +11,8 @@
   * `id: INTEGER PRIMARY KEY` — уникальный идентификатор записи
   * `tg_id: INTEGER UNIQUE` — Telegram ID пользователя
   * `name: TEXT` — имя или никнейм пользователя
+  * `is_active: INTEGER` — доступ к боту (0/1)
+  * `requested_at: TIMESTAMP` — когда отправлена заявка
 * Хранится в таблице `users` (создаётся в `database.py`).
 
 ### Request
@@ -47,6 +49,7 @@
 | ------------ | ------------------------------- | ---------------------------------------------------------------- |
 | **bot-core** | Логика Telegram-бота            | `main.py` (`start_handler`, `help_handler`, `ping_handler`, `create_bot_and_dispatcher`, `main`) |
 | **database** | Инициализация и миграции БД     | `database.py` (`init_db`, `get_db`, `log_request`, `log_response`, `CREATE_USERS`, `CREATE_REQUESTS`, `CREATE_RESPONSES`, `CREATE_MODELS`) |
+| **services** | Бизнес-логика пользователей     | `services/user_service.py`, `AuthMiddleware`, `admin_router` |
 | **tests**    | Юнит- и E2E-тесты               | `tests/conftest.py`, `tests/test_start.py`, `tests/test_help.py`, `tests/test_smoke.py`                       |
 | **config**   | Конфигурация окружения          | `.env` (переменная `BOT_TOKEN`), `.env.example`                                  |
 | **CI/CD**    | Настройка сборки и тестирования | `.github/workflows/ci.yml`                                       |

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer package."""

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -1,0 +1,49 @@
+"""User management service.
+
+Handles creation and activation of Telegram users.
+`is_active` indicates whether the user is allowed to interact with the bot.
+"""
+
+from typing import Any, Dict, List
+
+from bot import database
+
+
+async def get_or_create_user(tg_id: int, name: str) -> Dict[str, Any]:
+    """Return user record, creating it if necessary."""
+    async with database.get_db() as db:
+        cur = await db.execute(
+            "SELECT id, is_active FROM users WHERE tg_id = ?",
+            (tg_id,),
+        )
+        row = await cur.fetchone()
+        if row:
+            return {"id": row[0], "is_active": row[1]}
+
+        cur = await db.execute(
+            "INSERT INTO users(tg_id, name, requested_at)\n"
+            "VALUES(?, ?, CURRENT_TIMESTAMP)",
+            (tg_id, name),
+        )
+        await db.commit()
+        return {"id": cur.lastrowid, "is_active": 0}
+
+
+async def set_active(tg_id: int, value: bool) -> None:
+    """Update user active status."""
+    async with database.get_db() as db:
+        await db.execute(
+            "UPDATE users SET is_active = ? WHERE tg_id = ?",
+            (1 if value else 0, tg_id),
+        )
+        await db.commit()
+
+
+async def pending_users() -> List[Dict[str, Any]]:
+    """Return list of users waiting for approval."""
+    async with database.get_db() as db:
+        cur = await db.execute(
+            "SELECT tg_id, name FROM users WHERE is_active = 0",
+        )
+        rows = await cur.fetchall()
+        return [{"tg_id": r[0], "name": r[1]} for r in rows]

--- a/tests/bot/test_auth.py
+++ b/tests/bot/test_auth.py
@@ -1,0 +1,121 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from aiogram import Bot, types
+from aiogram.types import Update
+
+from bot import database
+from bot.main import create_bot_and_dispatcher
+
+
+@pytest.fixture(autouse=True)
+def fake_env(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123:TEST")
+    monkeypatch.setenv("ADMIN_CHAT_ID", "999")
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest_asyncio.fixture()
+async def temp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "auth.db"
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+    await database.init_db()
+    return db_path
+
+
+@pytest_asyncio.fixture()
+async def bot_and_dp(monkeypatch, temp_db):
+    bot, dp = create_bot_and_dispatcher()
+
+    calls = []
+
+    async def fake_answer(self, text, **kwargs):
+        calls.append((self.chat.id, text, kwargs))
+        return types.Message(
+            message_id=0,
+            date=datetime.now(),
+            chat=self.chat,
+            from_user=self.from_user,
+            text=text,
+        )
+
+    async def fake_send(self, chat_id, text, **kwargs):
+        calls.append((chat_id, text, kwargs))
+        return types.Message(
+            message_id=0,
+            date=datetime.now(),
+            chat=types.Chat(id=chat_id, type="private"),
+            from_user=None,
+            text=text,
+        )
+
+    monkeypatch.setattr(types.Message, "answer", fake_answer)
+    monkeypatch.setattr(Bot, "send_message", fake_send)
+
+    return bot, dp, calls
+
+
+@pytest.mark.asyncio
+async def test_authorization_flow(bot_and_dp):
+    bot, dp, calls = bot_and_dp
+
+    start_msg = types.Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=types.Chat(id=123, type="private"),
+        from_user=types.User(id=123, is_bot=False, first_name="User"),
+        text="/start",
+    )
+    await dp.feed_update(bot, Update(update_id=1, message=start_msg))
+
+    assert len(calls) == 2
+    user_chat, user_text, _ = calls[0]
+    assert user_chat == 123
+    assert "заявка" in user_text.lower()
+
+    admin_chat, _, kwargs = calls[1]
+    assert admin_chat == 999
+    keyboard = kwargs.get("reply_markup")
+    assert keyboard is not None
+    assert "Одобрить" in keyboard.inline_keyboard[0][0].text
+
+    async with database.get_db() as db:
+        cur = await db.execute("SELECT is_active FROM users WHERE tg_id=123")
+        row = await cur.fetchone()
+        assert row and row[0] == 0
+
+    approve_msg = types.Message(
+        message_id=2,
+        date=datetime.now(),
+        chat=types.Chat(id=999, type="private"),
+        from_user=types.User(id=999, is_bot=False, first_name="Admin"),
+        text="/admin approve 123",
+    )
+    await dp.feed_update(bot, Update(update_id=2, message=approve_msg))
+
+    assert any(c[0] == 123 and "доступ открыт" in c[1].lower() for c in calls)
+
+    async with database.get_db() as db:
+        cur = await db.execute("SELECT is_active FROM users WHERE tg_id=123")
+        row = await cur.fetchone()
+        assert row and row[0] == 1
+
+    ping_msg = types.Message(
+        message_id=3,
+        date=datetime.now(),
+        chat=types.Chat(id=123, type="private"),
+        from_user=types.User(id=123, is_bot=False, first_name="User"),
+        text="/ping",
+    )
+    await dp.feed_update(bot, Update(update_id=3, message=ping_msg))
+
+    assert len(calls) == 5
+    assert calls[-1][1] == "Bot ready"

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -4,9 +4,11 @@ import asyncio
 from datetime import datetime
 
 import pytest
-from aiogram import types
+import pytest_asyncio
+from aiogram import Bot, types
 from aiogram.types import Update
 
+from bot import database
 from bot.main import create_bot_and_dispatcher
 
 
@@ -22,8 +24,16 @@ def event_loop():
     loop.close()
 
 
+@pytest_asyncio.fixture()
+async def temp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "help.db"
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+    await database.init_db()
+    return db_path
+
+
 @pytest.fixture()
-def bot_and_dp(monkeypatch):
+def bot_and_dp(monkeypatch, temp_db):
     bot, dp = create_bot_and_dispatcher()
 
     send_calls = []
@@ -38,7 +48,18 @@ def bot_and_dp(monkeypatch):
             text=text,
         )
 
+    async def fake_send(self, chat_id, text, **kwargs):
+        send_calls.append((chat_id, text))
+        return types.Message(
+            message_id=0,
+            date=datetime.now(),
+            chat=types.Chat(id=chat_id, type="private"),
+            from_user=None,
+            text=text,
+        )
+
     monkeypatch.setattr(types.Message, "answer", fake_answer)
+    monkeypatch.setattr(Bot, "send_message", fake_send)
 
     return bot, dp, send_calls
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,9 +3,11 @@ import asyncio
 from datetime import datetime
 
 import pytest
-from aiogram import types
+import pytest_asyncio
+from aiogram import Bot, types
 from aiogram.types import Update
 
+from bot import database
 from bot.main import create_bot_and_dispatcher
 
 
@@ -21,8 +23,16 @@ def event_loop():
     loop.close()
 
 
+@pytest_asyncio.fixture()
+async def temp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "smoke.db"
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+    await database.init_db()
+    return db_path
+
+
 @pytest.fixture()
-def bot_and_dp(monkeypatch):
+def bot_and_dp(monkeypatch, temp_db):
     bot, dp = create_bot_and_dispatcher()
 
     send_calls = []
@@ -37,7 +47,18 @@ def bot_and_dp(monkeypatch):
             text=text,
         )
 
+    async def fake_send(self, chat_id, text, **kwargs):
+        send_calls.append((chat_id, text))
+        return types.Message(
+            message_id=0,
+            date=datetime.now(),
+            chat=types.Chat(id=chat_id, type="private"),
+            from_user=None,
+            text=text,
+        )
+
     monkeypatch.setattr(types.Message, "answer", fake_answer)
+    monkeypatch.setattr(Bot, "send_message", fake_send)
 
     return bot, dp, send_calls
 


### PR DESCRIPTION
## Summary
- add AuthMiddleware and admin router for approving new users
- extend SQLite schema with `is_active` and `requested_at`
- implement `user_service` helpers
- update create_bot_and_dispatcher to include middleware and router
- document the authorization flow and update context
- add comprehensive auth test and adjust existing tests
- enable mypy check for services package

## Testing
- `pre-commit run --files bot/middleware.py tests/bot/test_auth.py tests/test_start.py tests/test_help.py tests/test_smoke.py bot/main.py services/user_service.py docs/CONTEXT.md README.md .env.example .pre-commit-config.yaml bot/database.py bot/admin.py services/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567c14826c832abef8df2f0ec125a4