### PR TITLE
Iteration 3: context buffer & splitting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Copy this file to .env and set your Telegram bot token
 BOT_TOKEN=
 ADMIN_CHAT_ID=0
+MAX_CONTEXT_MESSAGES=20

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ The bot uses a SQLite file `bot.db`. It is created by calling `init_db()` from
 ## Authorization
 
 When a new user sends `/start`, the bot records the request and notifies the chat defined in `ADMIN_CHAT_ID`. Until the admin approves the user, any commands besides `/start` are ignored.
+
+## Context management & limits
+
+Messages for each chat are stored in an in-memory buffer. The number of stored pairs is controlled by `MAX_CONTEXT_MESSAGES` (default 20). Command `/clear` wipes the history for the chat. Answers longer than 4096 characters are automatically split before sending.

--- a/bot/context_middleware.py
+++ b/bot/context_middleware.py
@@ -1,0 +1,15 @@
+from aiogram import BaseMiddleware, types
+
+from services.context import ContextBuffer
+
+
+class ContextMiddleware(BaseMiddleware):
+    def __init__(self, buffer: ContextBuffer) -> None:
+        super().__init__()
+        self.buffer = buffer
+
+    async def __call__(self, handler, event: types.TelegramObject, data):
+        if isinstance(event, types.Message) and event.text is not None:
+            self.buffer.add(event.chat.id, "user", event.text)
+        result = await handler(event, data)
+        return result

--- a/bot/conversation.py
+++ b/bot/conversation.py
@@ -1,0 +1,21 @@
+from aiogram import Router, types
+from aiogram.filters import Command
+
+from bot.utils import send_long_message
+from services.context import ContextBuffer
+
+
+def get_conversation_router(buffer: ContextBuffer) -> Router:
+    router = Router()
+
+    @router.message(Command(commands=["clear"]))
+    async def clear_ctx(message: types.Message) -> None:
+        buffer.clear(message.chat.id)
+        await send_long_message(
+            message.bot,
+            message.chat.id,
+            "Контекст очищен ✅",
+            log=False,
+        )
+
+    return router

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,14 @@
+import textwrap
+
+from aiogram import Bot
+
+
+async def send_long_message(
+    bot: Bot, chat_id: int, text: str, *, log: bool = True
+) -> None:
+    """Split messages longer than 4096 characters and send sequentially."""
+    chunks = textwrap.wrap(text, width=4096)
+    for chunk in chunks:
+        await bot.send_message(chat_id, chunk)
+    if log and hasattr(bot, "context_buffer"):
+        bot.context_buffer.add(chat_id, "assistant", text)

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -47,9 +47,9 @@
 
 | Модуль       | Описание                        | Файлы и папки                                                    |
 | ------------ | ------------------------------- | ---------------------------------------------------------------- |
-| **bot-core** | Логика Telegram-бота            | `main.py` (`start_handler`, `help_handler`, `ping_handler`, `create_bot_and_dispatcher`, `main`) |
+| **bot-core** | Логика Telegram-бота            | `main.py` (`start_handler`, `help_handler`, `ping_handler`, `create_bot_and_dispatcher`, `main`), `conversation.py`, `utils.py` |
 | **database** | Инициализация и миграции БД     | `database.py` (`init_db`, `get_db`, `log_request`, `log_response`, `CREATE_USERS`, `CREATE_REQUESTS`, `CREATE_RESPONSES`, `CREATE_MODELS`) |
-| **services** | Бизнес-логика пользователей     | `services/user_service.py`, `AuthMiddleware`, `admin_router` |
+| **services** | Бизнес-логика пользователей     | `services/user_service.py`, `AuthMiddleware`, `ContextBuffer`, `admin_router` |
 | **tests**    | Юнит- и E2E-тесты               | `tests/conftest.py`, `tests/test_start.py`, `tests/test_help.py`, `tests/test_smoke.py`                       |
 | **config**   | Конфигурация окружения          | `.env` (переменная `BOT_TOKEN`), `.env.example`                                  |
 | **CI/CD**    | Настройка сборки и тестирования | `.github/workflows/ci.yml`                                       |
@@ -61,5 +61,7 @@
 * **Добавить новые поля в User:** редактируйте `CREATE TABLE users` в `database.py` и обновляйте `init_db()`.
 * **Тесты на новые функции бота:** добавляйте файлы в папку `tests/`, используйте `pytest` и мок `BOT_TOKEN` через `conftest.py`.
 * **CI-пайплайн:** для проверки lint, тестов и автодеплоя смотрите `.github/workflows/ci.yml`.
+
+* **Контекст переписки:** `ContextBuffer` сохраняет последние сообщения чата; очистить историю можно командой `/clear`.
 
 > **Важно:** актуализируйте этот файл при расширении модели данных или изменении структуры проекта.

--- a/services/context.py
+++ b/services/context.py
@@ -1,0 +1,26 @@
+"""Per-chat message history buffer.
+
+Stores recent user and bot messages to preserve conversation context.
+Messages are kept in insertion order and trimmed to ``max_messages`` entries.
+"""
+
+from collections import deque
+from typing import Deque, Dict, List, Tuple
+
+
+class ContextBuffer:
+    """In-memory circular buffer for chat messages."""
+
+    def __init__(self, max_messages: int = 20) -> None:
+        self.max_messages = max_messages
+        self._data: Dict[int, Deque[Tuple[str, str]]] = {}
+
+    def add(self, chat_id: int, role: str, text: str) -> None:
+        queue = self._data.setdefault(chat_id, deque(maxlen=self.max_messages))
+        queue.append((role, text))
+
+    def get(self, chat_id: int) -> List[Tuple[str, str]]:
+        return list(self._data.get(chat_id, deque()))
+
+    def clear(self, chat_id: int) -> None:
+        self._data.pop(chat_id, None)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,109 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from aiogram import Bot, types
+from aiogram.types import Update
+
+from bot import database
+from bot.main import create_bot_and_dispatcher
+from bot.utils import send_long_message
+
+
+@pytest.fixture(autouse=True)
+def fake_env(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123:TEST")
+    monkeypatch.setenv("ADMIN_CHAT_ID", "0")
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest_asyncio.fixture()
+async def temp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "context.db"
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+    await database.init_db()
+    return db_path
+
+
+@pytest.fixture()
+def bot_and_dp(monkeypatch, temp_db):
+    bot, dp = create_bot_and_dispatcher()
+
+    calls = []
+
+    async def fake_answer(self, text, **kwargs):
+        calls.append(text)
+        return types.Message(
+            message_id=0,
+            date=datetime.now(),
+            chat=self.chat,
+            from_user=self.from_user,
+            text=text,
+        )
+
+    async def fake_send(self, chat_id, text, **kwargs):
+        calls.append(text)
+        return types.Message(
+            message_id=0,
+            date=datetime.now(),
+            chat=types.Chat(id=chat_id, type="private"),
+            from_user=None,
+            text=text,
+        )
+
+    monkeypatch.setattr(types.Message, "answer", fake_answer)
+    monkeypatch.setattr(Bot, "send_message", fake_send)
+
+    return bot, dp, calls
+
+
+@pytest.mark.asyncio
+async def test_history(bot_and_dp):
+    bot, dp, calls = bot_and_dp
+    chat_id = 12345
+    for i, text in enumerate(["one", "two", "three"], start=1):
+        msg = types.Message(
+            message_id=i,
+            date=datetime.now(),
+            chat=types.Chat(id=chat_id, type="private"),
+            from_user=types.User(id=chat_id, is_bot=False, first_name="User"),
+            text=text,
+        )
+        await dp.feed_update(bot, Update(update_id=i, message=msg))
+
+    buffer = dp.context_buffer
+    assert len(buffer.get(chat_id)) == 3
+
+
+@pytest.mark.asyncio
+async def test_clear_command(bot_and_dp):
+    bot, dp, calls = bot_and_dp
+    chat_id = 1
+    msg = types.Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=types.Chat(id=chat_id, type="private"),
+        from_user=types.User(id=chat_id, is_bot=False, first_name="User"),
+        text="/clear",
+    )
+    await dp.feed_update(bot, Update(update_id=1, message=msg))
+
+    buffer = dp.context_buffer
+    assert len(buffer.get(chat_id)) == 0
+    assert any("Контекст очищен" in t for t in calls)
+
+
+@pytest.mark.asyncio
+async def test_split_long_message(bot_and_dp):
+    bot, dp, calls = bot_and_dp
+    long_text = "x" * 6000
+    await send_long_message(bot, 2, long_text)
+    assert len(calls) == 2
+    assert "".join(calls) == long_text


### PR DESCRIPTION
## Summary
- implement per-chat ContextBuffer service
- log user messages via ContextMiddleware
- split long answers with `send_long_message`
- add `/clear` command and update bot factory
- document new configuration and module layout
- tests for conversation logic

## Testing
- `pre-commit run --files bot/main.py bot/conversation.py services/context.py bot/context_middleware.py bot/utils.py tests/test_context.py README.md docs/CONTEXT.md .env.example`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685818fbad68832a9e6258a8147c45a7