### PR TITLE
Implement docker compose & CI publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.log
+.env
+.venv/
+tests/
+.git
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install deps
         run: pip install -r requirements.txt pre-commit "httpx[socks]"
       - name: DB tests
@@ -17,5 +17,30 @@ jobs:
         run: pre-commit run --all-files
       - name: Test
         run: pytest -q
-      - name: Docker dry-run
-        run: docker build -t bot:test .
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: docker build -t tgbot:test .
+      - name: Image tests
+        run: pytest -q tests/deploy/test_image.py
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}:${{ github.sha }} .
+          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:latest
+            docker push ghcr.io/${{ github.repository }}:latest
+          fi
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,9 @@ repos:
         name: mypy strict admin router
         files: ^bot/admin.py$
         args: [--strict, --ignore-missing-imports, --follow-imports=skip, --disable-error-code=misc]
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+        files: Dockerfile
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,9 +44,12 @@ repos:
         name: mypy strict admin router
         files: ^bot/admin.py$
         args: [--strict, --ignore-missing-imports, --follow-imports=skip, --disable-error-code=misc]
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.0
+  - repo: local
     hooks:
       - id: hadolint
+        name: hadolint
+        entry: scripts/hadolint.sh
+        language: script
+        pass_filenames: true
         files: Dockerfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,29 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
+
+ARG BUILD_ENV=prod
+ARG VERSION=0.0.0
+ENV PYTHONUNBUFFERED=1 \
+    TZ=Europe/Berlin
+
 WORKDIR /app
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
-CMD ["python", "-m", "bot.main"]
+
+COPY scripts/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+COPY bot ./bot
+COPY providers ./providers
+COPY scheduler ./scheduler
+COPY services ./services
+COPY logging_config.py ./logging_config.py
+
+EXPOSE 8080
+HEALTHCHECK CMD ["python", "-m", "bot.main", "--ping"]
+
+LABEL version=$VERSION
+
+USER nobody
+ENTRYPOINT ["/app/entrypoint.sh"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+compose-up:
+docker compose -f deploy/docker-compose.dev.yml up -d --build
+
+compose-down:
+docker compose -f deploy/docker-compose.dev.yml down
+
+build-image:
+docker build -t tgbot:local .
+
+push-image:
+docker push tgbot:local
+

--- a/README.md
+++ b/README.md
@@ -90,3 +90,32 @@ Logs are emitted in JSON format using `structlog`. Example entry:
 Configure log level via `LOG_LEVEL` (default `INFO`). To send errors to Sentry
 set `SENTRY_DSN`. All uncaught exceptions are logged and a short message is sent
 to the chat defined by `ADMIN_CHAT_ID`.
+
+## Docker
+
+[![CI](https://github.com/your/repo/actions/workflows/ci.yml/badge.svg)](https://github.com/your/repo/actions/workflows/ci.yml)
+[![GHCR](https://img.shields.io/badge/ghcr-image-blue)](https://ghcr.io/)
+[![Deploy to Railway](https://railway.app/button.svg)](https://railway.app/template/your)
+
+### Development
+
+```bash
+docker compose -f deploy/docker-compose.dev.yml up -d --build
+```
+
+Stop with:
+
+```bash
+docker compose -f deploy/docker-compose.dev.yml down
+```
+
+### Production
+
+Pull image from GHCR and run:
+
+```bash
+docker compose -f deploy/docker-compose.prod.yml up -d
+```
+
+Data is stored in `./data` volume.
+

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  bot:
+    build: ..
+    volumes:
+      - ../data:/app/data
+    env_file: ../.env
+    restart: on-failure
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "python", "-m", "bot.main", "--ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  bot:
+    image: ghcr.io/example/tgbot:latest
+    environment:
+      BOT_TOKEN: ${BOT_TOKEN}
+      ADMIN_CHAT_ID: ${ADMIN_CHAT_ID}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      TZ: Europe/Berlin
+    restart: always
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "python", "-m", "bot.main", "--ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+

--- a/deploy/railway.json
+++ b/deploy/railway.json
@@ -1,0 +1,8 @@
+{
+  "envs": {
+    "BOT_TOKEN": "",
+    "ADMIN_CHAT_ID": "",
+    "LOG_LEVEL": "INFO"
+  }
+}
+

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -70,10 +70,12 @@
 | **providers** | Абстракции LLM-провайдеров | `providers/base.py`, `gemini.py`, `mistral.py`, `dipseek.py`, `registry.py` |
 | **scheduler** | Периодические задачи обновления моделей | `scheduler/jobs.py`, `scheduler/runner.py` |
 | **tests**    | Юнит- и E2E-тесты               | `tests/conftest.py`, `tests/test_start.py`, `tests/test_help.py`, `tests/test_smoke.py`                       |
-| **config**   | Конфигурация окружения          | `.env` (переменная `BOT_TOKEN`), `.env.example`                                  |
+| **config**   | Конфигурация окружения          | `.env` (переменная `BOT_TOKEN`), `.env.example` (переменные `BOT_TOKEN`, `ADMIN_CHAT_ID`, `TZ`)                                  |
 | **CI/CD**    | Настройка сборки и тестирования | `.github/workflows/ci.yml`                                       |
 | **deps**     | Зависимости проекта             | `requirements.txt`                                               |
 | **logging**  | Структурированный вывод и перехват ошибок | `logging_config.py`, `bot/error_middleware.py` |
+| **deploy**   | Docker Compose и скрипты запуска | `deploy/docker-compose.dev.yml`, `deploy/docker-compose.prod.yml`, `railway.json` |
+| **scripts**  | Точки входа и утилиты       | `scripts/entrypoint.sh`, `Makefile` |
 
 ## 3. Навигация для агентов
 
@@ -87,3 +89,4 @@
 * **Обработка файлов:** `file_handlers.py` сохраняет присланные документы в `FILES_DIR` и передаёт их содержимое в LLM при поддержке модели.
 
 > **Важно:** актуализируйте этот файл при расширении модели данных или изменении структуры проекта.
+

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,7 @@
+# Deploy guide
+
+1. Clone the repo and copy `.env.example` to `.env`.
+2. Run `make compose-up`.
+3. Verify health via `curl http://localhost:8080/ping`.
+4. Stop services with `make compose-down`.
+

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+python - <<'PY'
+import asyncio
+from bot import database
+asyncio.run(database.init_db())
+PY
+exec python -m bot.main
+

--- a/scripts/hadolint.sh
+++ b/scripts/hadolint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+if command -v hadolint >/dev/null 2>&1; then
+    DL=hadolint
+else
+    DL=/tmp/hadolint
+    if [ ! -x "$DL" ]; then
+        curl -L -o "$DL" https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+        chmod +x "$DL"
+    fi
+fi
+exec "$DL" "$@"

--- a/tests/deploy/test_image.py
+++ b/tests/deploy/test_image.py
@@ -1,0 +1,113 @@
+import os
+import subprocess
+import time
+
+import pytest
+
+IMAGE_TAG = "tgbot:test"
+COMPOSE_FILE = "deploy/docker-compose.dev.yml"
+
+
+def has_docker() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0
+
+
+@pytest.fixture(scope="module")
+def skip_if_no_docker():
+    if not has_docker():
+        pytest.skip("docker not available")
+
+
+@pytest.mark.usefixtures("skip_if_no_docker")
+def test_build_and_run_image(tmp_path):
+    subprocess.check_call(["docker", "build", "-t", IMAGE_TAG, "."])
+    env = {
+        "BOT_TOKEN": "123:TEST",
+        "ADMIN_CHAT_ID": "1",
+        "LOG_LEVEL": "INFO",
+        "TZ": "Europe/Berlin",
+    }
+    cmd = ["docker", "run", "-d", "--rm"]
+    for k, v in env.items():
+        cmd += ["-e", f"{k}={v}"]
+    cmd.append(IMAGE_TAG)
+    container_id = subprocess.check_output(cmd).decode().strip()
+    try:
+        for _ in range(20):
+            logs = subprocess.check_output(
+                [
+                    "docker",
+                    "logs",
+                    container_id,
+                ]
+            ).decode()
+            if "bot_started" in logs:
+                break
+            time.sleep(1)
+        else:
+            raise AssertionError("bot did not start")
+    finally:
+        subprocess.check_call(["docker", "stop", container_id])
+
+
+@pytest.mark.usefixtures("skip_if_no_docker")
+def test_docker_compose(tmp_path):
+    data_dir = tmp_path / "data"
+    env = os.environ.copy()
+    env.update(
+        {
+            "BOT_TOKEN": "123:TEST",
+            "ADMIN_CHAT_ID": "1",
+            "LOG_LEVEL": "INFO",
+            "TZ": "Europe/Berlin",
+        }
+    )
+    subprocess.check_call(
+        [
+            "docker",
+            "compose",
+            "-f",
+            COMPOSE_FILE,
+            "up",
+            "-d",
+            "--build",
+        ],
+        env=env,
+    )
+    try:
+        for _ in range(20):
+            out = subprocess.check_output(
+                [
+                    "docker",
+                    "compose",
+                    "-f",
+                    COMPOSE_FILE,
+                    "ps",
+                    "--format",
+                    "json",
+                ]
+            )
+            if b"healthy" in out:
+                break
+            time.sleep(1)
+        else:
+            raise AssertionError("compose service not healthy")
+        assert data_dir.exists()
+    finally:
+        subprocess.check_call(
+            [
+                "docker",
+                "compose",
+                "-f",
+                COMPOSE_FILE,
+                "down",
+            ]
+        )


### PR DESCRIPTION
## Summary
- add docker-compose files and entrypoint script
- extend CI to build and publish image
- update docs with deploy instructions and badges
- provide Makefile and Docker ignore
- add tests for docker image and compose

## Testing
- `pre-commit run --files .github/workflows/ci.yml .pre-commit-config.yaml Dockerfile README.md docs/CONTEXT.md .dockerignore Makefile docs/deploy.md scripts/entrypoint.sh tests/deploy/test_image.py deploy/docker-compose.dev.yml deploy/docker-compose.prod.yml deploy/railway.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f2ca6928832a9a891d31fdb49573